### PR TITLE
fix: paths had extra html

### DIFF
--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -1,6 +1,6 @@
 Title: CoDaS-HEP Overview
 date: 2017-03-21 07:51
-slug: about.html
+slug: about
 Authors: Peter Elmer
 Summary: Computational and Data Science for High Energy Physics
 Template: page

--- a/content/pages/application.md
+++ b/content/pages/application.md
@@ -1,6 +1,6 @@
 Title: CoDaS-HEP School Application
 date: 2017-05-16 07:51
-slug: application.html
+slug: application
 Authors: Peter Elmer
 Summary: Computation and Data Science for High Energy Physics
 Template: page

--- a/content/pages/participants-2017.md
+++ b/content/pages/participants-2017.md
@@ -1,6 +1,6 @@
 Title: Participants in CoDaS-HEP 2017 school
 date: 2017-05-16 07:51
-slug: participants-2017.html
+slug: participants-2017
 Authors: Peter Elmer
 Summary: Participants in CoDaS-HEP 2017 school
 Template: page

--- a/content/pages/participants-2018.md
+++ b/content/pages/participants-2018.md
@@ -1,6 +1,6 @@
 Title: Participants in CoDaS-HEP 2018 school
 date: 2018-07-24 07:51
-slug: participants-2018.html
+slug: participants-2018
 Authors: Peter Elmer
 Summary: Participants in CoDaS-HEP 2018 school
 Template: page

--- a/content/pages/participants-2019.md
+++ b/content/pages/participants-2019.md
@@ -1,6 +1,6 @@
 Title: Participants in CoDaS-HEP 2019 school
 date: 2019-07-01 07:51
-slug: participants-2019.html
+slug: participants-2019
 Authors: Peter Elmer
 Summary: Participants in CoDaS-HEP 2019 school
 Template: page

--- a/content/pages/platform-2019.md
+++ b/content/pages/platform-2019.md
@@ -1,6 +1,6 @@
 Title: Platform Setup Instructions
 date: 2019-07-22 13:10
-slug: platform-2019.html 
+slug: platform-2019
 Authors: Savannah Thais 
 Summary: Instructions for setting up the remote CoDaS platform with conda image
 Template: page

--- a/content/pages/preparation-2017.md
+++ b/content/pages/preparation-2017.md
@@ -1,6 +1,6 @@
 Title: Advance preparation for laptops
 date: 2017-07-01 07:51
-slug: preparation-2017.html
+slug: preparation-2017
 Authors: Peter Elmer
 Summary: Advance preparation for laptops
 Template: page

--- a/content/pages/preparation.md
+++ b/content/pages/preparation.md
@@ -1,6 +1,6 @@
 Title: Advance preparation for laptops
 date: 2017-07-01 07:51
-slug: preparation.html
+slug: preparation
 Authors: Peter Elmer
 Summary: Advance preparation for laptops
 Template: page

--- a/content/pages/reimbursement-2017.md
+++ b/content/pages/reimbursement-2017.md
@@ -1,6 +1,6 @@
 Title: Reimbursement for Travel to Princeton
 date: 2017-05-16 07:51
-slug: reimbursement-2017.html
+slug: reimbursement-2017
 Authors: Peter Elmer
 Summary: Reimbursement for Travel Expenses
 Template: page

--- a/content/pages/reimbursement-dancecodas2022.md
+++ b/content/pages/reimbursement-dancecodas2022.md
@@ -1,6 +1,6 @@
 Title: Reimbursement for Travel to Snowmass in Seattle
 date: 2022-06-13 07:51
-slug: reimbursement-dancecodas2022.html
+slug: reimbursement-dancecodas2022
 Authors: Peter Elmer
 Summary: Reimbursement for Travel Expenses - DANCE/CoDaS@Snowmass 2022
 Template: page

--- a/content/pages/reimbursement.md
+++ b/content/pages/reimbursement.md
@@ -1,6 +1,6 @@
 Title: Reimbursement for Travel to Princeton
 date: 2017-05-16 07:51
-slug: reimbursement.html
+slug: reimbursement
 Authors: Peter Elmer
 Summary: Reimbursement for Travel Expenses
 Template: page

--- a/content/pages/travel-princeton-2017.md
+++ b/content/pages/travel-princeton-2017.md
@@ -1,6 +1,6 @@
 Title: Travel to Princeton (2017 Version)
 date: 2017-05-16 07:51
-slug: travel-princeton-2017.html
+slug: travel-princeton-2017
 Authors: Peter Elmer
 Summary: Travel to Princeton and Local Princeton Information
 Template: page

--- a/content/pages/travel-princeton-2018.md
+++ b/content/pages/travel-princeton-2018.md
@@ -1,6 +1,6 @@
 Title: Travel to Princeton (2018 Version)
 date: 2017-05-16 07:51
-slug: travel-princeton-2018.html
+slug: travel-princeton-2018
 Authors: Peter Elmer
 Summary: Travel to Princeton and Local Princeton Information
 Template: page

--- a/content/pages/travel-princeton-2019.md
+++ b/content/pages/travel-princeton-2019.md
@@ -1,6 +1,6 @@
 Title: Travel to Princeton (2019 Version)
 date: 2017-05-16 07:51
-slug: travel-princeton-2019.html
+slug: travel-princeton-2019
 Authors: Peter Elmer
 Summary: Travel to Princeton and Local Princeton Information
 Template: page

--- a/content/pages/travel-princeton.md
+++ b/content/pages/travel-princeton.md
@@ -1,6 +1,6 @@
 Title: Travel to Princeton (2022 Version)
 date: 2017-05-16 07:51
-slug: travel-princeton.html
+slug: travel-princeton
 Authors: Peter Elmer
 Summary: Travel to Princeton and Local Princeton Information
 Template: page

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
-pelican
-Markdown<3.4
+pelican  # tipue search deprecated in 4.8
+Markdown<3.4  # broken with pelican
 fabric
 beautifulsoup4
 six


### PR DESCRIPTION
All paths had an extra .html on the end, making `thing.html.html`. The webserver was hiding the last `.html` making links and things work.
